### PR TITLE
feat(math): add coth sech and csch functions

### DIFF
--- a/lib/src/math/hyperbolic.dart
+++ b/lib/src/math/hyperbolic.dart
@@ -34,4 +34,13 @@ extension HyperbolicNumberExtension on num {
 
   /// Returns the hyperbolic arc-tangent of this [num].
   double atanh() => ((1 + this) / (1 - this)).log() / 2;
+
+  /// Returns the hyperbolic cotangent of this [num].
+  double coth() => 1 / tanh();
+
+  /// Returns the hyperbolic secant of this [num].
+  double sech() => 1 / cosh();
+
+  /// Returns the hyperbolic cosecant of this [num].
+  double csch() => 1 / sinh();
 }

--- a/test/math_test.dart
+++ b/test/math_test.dart
@@ -450,6 +450,21 @@ void main() {
       expect(1.atanh(), double.infinity);
       expect(2.atanh(), isNaN);
     });
+    test('coth', () {
+      expect(0.coth(), double.infinity);
+      expect(1.coth(), closeTo(1.3130352854993312, epsilon));
+      expect(double.infinity.coth(), closeTo(1, epsilon));
+    });
+    test('sech', () {
+      expect(0.sech(), closeTo(1, epsilon));
+      expect(1.sech(), closeTo(0.6480542736638855, epsilon));
+      expect(double.infinity.sech(), closeTo(0, epsilon));
+    });
+    test('csch', () {
+      expect(0.csch(), double.infinity);
+      expect(1.csch(), closeTo(0.8509181282393216, epsilon));
+      expect(double.infinity.csch(), closeTo(0, epsilon));
+    });
   });
   group('isProbablyPrime', () {
     const max = 100000;


### PR DESCRIPTION
Add additional hyperbolic functions and test cases for the new functions `sinh(x)`, `cosh(x)` and `tanh(x)`

Addresses issue: https://github.com/renggli/dart-more/issues/29

```dart
coth(x) = 1 / tanh(x)

sech(x) = 1 / cosh(x)

csch(x) = 1 / sinh()
```

