### PR TITLE
feat(math): add acoth asech and acsch functions

### DIFF
--- a/lib/src/math/hyperbolic.dart
+++ b/lib/src/math/hyperbolic.dart
@@ -35,6 +35,15 @@ extension HyperbolicNumberExtension on num {
   /// Returns the hyperbolic arc-tangent of this [num].
   double atanh() => ((1 + this) / (1 - this)).log() / 2;
 
+  /// Returns the inverse hyperbolic tangent of this [num].
+  double acoth() => (1 / this).atanh();
+
+  /// Returns the the hyperbolic arcsecant of this [num].
+  double asech() => (1 / this).acosh();
+
+  /// Returns the inverse hyperbolic cosecant of this [num].
+  double acsch() => (1 / this).asinh();
+
   /// Returns the hyperbolic cotangent of this [num].
   double coth() => 1 / tanh();
 

--- a/test/math_test.dart
+++ b/test/math_test.dart
@@ -450,6 +450,24 @@ void main() {
       expect(1.atanh(), double.infinity);
       expect(2.atanh(), isNaN);
     });
+    test('acoth', () {
+      expect(-2.acoth(), closeTo(-0.5493061443340548, epsilon));
+      expect(-1.acoth(), double.negativeInfinity);
+      expect(0.acoth(), isNaN);
+      expect(1.acoth(), double.infinity);
+      expect(2.acoth(), closeTo(0.5493061443340548, epsilon));
+    });
+    test('asech', () {
+      expect(1.asech(), closeTo(0, epsilon));
+      expect(0.5.asech(), closeTo(1.3169578969248166, epsilon));
+      expect(0.2.asech(), closeTo(2.2924316695611777, epsilon));
+      expect(2.asech(), isNaN);
+    });
+    test('acsch', () {
+      expect(1.acsch(), closeTo(0.881373587019543, epsilon));
+      expect((-1).acsch(), closeTo(-0.881373587019543, epsilon));
+      expect(0.acsch(), double.infinity);
+    });
     test('coth', () {
       expect(0.coth(), double.infinity);
       expect(1.coth(), closeTo(1.3130352854993312, epsilon));


### PR DESCRIPTION
Add the formulas for [acoth](https://mathjs.org/docs/reference/functions/acoth.html), [asech](https://mathjs.org/docs/reference/functions/asech.html) and [acsch](https://mathjs.org/docs/reference/functions/acsch.html)

Add tests as well for the added functions.

Addresses issue: https://github.com/renggli/dart-more/issues/31