### PR TITLE
feat(math): add support to convert degrees into radians and vice versa

### DIFF
--- a/lib/src/math/math.dart
+++ b/lib/src/math/math.dart
@@ -28,6 +28,12 @@ extension MathNumberExtension on num {
   /// Returns the square root of this [num].
   double sqrt() => math.sqrt(this);
 
+  /// Returns the degree of this [num] in degrees.
+  double toDegrees() => this * 180 / math.pi;
+
+  /// Returns the radian of this [num] in radians.
+  double toRadians() => this * math.pi / 180;
+
   /// Returns the natural exponent of this [num].
   double exp() => math.exp(this);
 

--- a/test/math_test.dart
+++ b/test/math_test.dart
@@ -657,6 +657,18 @@ void main() {
       expect(3.sqrt(), closeTo(1.7320508075688772, epsilon));
       expect(4.sqrt(), closeTo(2.00, epsilon));
     });
+    test('toDegrees', () {
+      expect(0.toDegrees(), closeTo(0, epsilon));
+      expect((math.pi / 2).toDegrees(), closeTo(90, epsilon));
+      expect(math.pi.toDegrees(), closeTo(180, epsilon));
+      expect(1.toDegrees(), closeTo(57.29577951308232, epsilon));
+    });
+    test('toRadians', () {
+      expect(0.toRadians(), closeTo(0, epsilon));
+      expect(90.toRadians(), closeTo(math.pi / 2, epsilon));
+      expect(180.toRadians(), closeTo(math.pi, epsilon));
+      expect(57.29577951308232.toRadians(), closeTo(1, epsilon));
+    });
     test('exp', () {
       expect(0.exp(), closeTo(1, epsilon));
       expect(1.exp(), closeTo(math.e, epsilon));


### PR DESCRIPTION
Add support for `toDegrees()` and `toRadians()`

Addresses issue: https://github.com/renggli/dart-more/issues/33

I have added it to [math.dart](https://github.com/rrbharath/dart-more/blob/7dfeef880c47de2012e987b722491dc1321db451/lib/src/math/math.dart#L31-L35) please let me know if this needs to be added in a different place