### PR TITLE
feat(bit): add setBit, clearBit and toggleBit

### DIFF
--- a/lib/src/math/bit.dart
+++ b/lib/src/math/bit.dart
@@ -26,4 +26,28 @@ extension BitUint32Extension on int {
   /// Returns the power of 2 that is greater or equal to this unsigned 32-bit
   /// integer.
   int get bitCeil => this <= 1 ? 1 : 1 << (this - 1).bitLength;
+
+  /// Returns this unsigned 32-bit integer with the bit at [index] set.
+  ///
+  /// The [index] must be between `0` and `31`, inclusive.
+  int setBit(int index) {
+    RangeError.checkValueInInterval(index, 0, 31, 'index');
+    return (this | (1 << index)) & 0xffffffff;
+  }
+
+  /// Returns this unsigned 32-bit integer with the bit at [index] cleared.
+  ///
+  /// The [index] must be between `0` and `31`, inclusive.
+  int clearBit(int index) {
+    RangeError.checkValueInInterval(index, 0, 31, 'index');
+    return this & ~(1 << index) & 0xffffffff;
+  }
+
+  /// Returns this unsigned 32-bit integer with the bit at [index] toggled.
+  ///
+  /// The [index] must be between `0` and `31`, inclusive.
+  int toggleBit(int index) {
+    RangeError.checkValueInInterval(index, 0, 31, 'index');
+    return (this ^ (1 << index)) & 0xffffffff;
+  }
 }

--- a/test/math_test.dart
+++ b/test/math_test.dart
@@ -134,6 +134,55 @@ void main() {
         expect(current.bitCeil, current);
       }
     });
+    group('setBit', () {
+      test('sets the selected bit', () {
+        expect(0.setBit(0), 0x00000001);
+        expect(0.setBit(31), 0x80000000);
+        expect(0xaaaaaaaa.setBit(0), 0xaaaaaaab);
+      });
+      test('keeps an already set bit', () {
+        expect(0xffffffff.setBit(13), 0xffffffff);
+      });
+      test('returns an unsigned 32-bit result', () {
+        expect((-1).setBit(0), 0xffffffff);
+      });
+      test('throws on invalid index', () {
+        expect(() => 0.setBit(-1), throwsRangeError);
+        expect(() => 0.setBit(32), throwsRangeError);
+      });
+    });
+    group('clearBit', () {
+      test('clears the selected bit', () {
+        expect(0x00000001.clearBit(0), 0);
+        expect(0x80000000.clearBit(31), 0);
+        expect(0xaaaaaaaa.clearBit(1), 0xaaaaaaa8);
+      });
+      test('keeps an already cleared bit', () {
+        expect(0.clearBit(13), 0);
+      });
+      test('returns an unsigned 32-bit result', () {
+        expect((-1).clearBit(0), 0xfffffffe);
+      });
+      test('throws on invalid index', () {
+        expect(() => 0.clearBit(-1), throwsRangeError);
+        expect(() => 0.clearBit(32), throwsRangeError);
+      });
+    });
+    group('toggleBit', () {
+      test('toggles the selected bit', () {
+        expect(0.toggleBit(0), 0x00000001);
+        expect(0.toggleBit(31), 0x80000000);
+        expect(0xaaaaaaaa.toggleBit(1), 0xaaaaaaa8);
+        expect(0xaaaaaaaa.toggleBit(0), 0xaaaaaaab);
+      });
+      test('returns an unsigned 32-bit result', () {
+        expect((-1).toggleBit(0), 0xfffffffe);
+      });
+      test('throws on invalid index', () {
+        expect(() => 0.toggleBit(-1), throwsRangeError);
+        expect(() => 0.toggleBit(32), throwsRangeError);
+      });
+    });
   });
   group('double', () {
     group('nextDown', () {


### PR DESCRIPTION
Add methods setBit, clearBit and toggleBit. Tests included

setBit(int index) => sets bit to 1 at the index
clearBit(int index) => sets bit to 0 at the index
toggleBit(int index) => toggles bit at the index. If 1 then it turns to 0 and vice versa

Addresses issue: https://github.com/renggli/dart-more/issues/35