### PR TITLE
feat(datetime): add isweekday and isweekend

### DIFF
--- a/lib/src/temporal/date_time/accessors.dart
+++ b/lib/src/temporal/date_time/accessors.dart
@@ -19,6 +19,13 @@ extension AccessorsDateTimeExtension on DateTime {
   /// The quarter `[1...4]`.
   int get quarter => 1 + (month - 1) ~/ 3;
 
+  /// Whether this day is Saturday or Sunday.
+  bool get isWeekend =>
+      weekday == DateTime.saturday || weekday == DateTime.sunday;
+
+  /// Whether this day is Monday through Friday.
+  bool get isWeekday => !isWeekend;
+
   /// The ISO week year.
   ///
   /// This is typically the current year, unless the week is part of the

--- a/test/temporal_test.dart
+++ b/test/temporal_test.dart
@@ -72,6 +72,22 @@ void main() {
           }
         }
       });
+      test('isWeekend & isWeekday', () {
+        expect(DateTime(2026, DateTime.may, 18).isWeekday, isTrue);
+        expect(DateTime(2026, DateTime.may, 18).isWeekend, isFalse);
+        expect(DateTime(2026, DateTime.may, 19).isWeekday, isTrue);
+        expect(DateTime(2026, DateTime.may, 19).isWeekend, isFalse);
+        expect(DateTime(2026, DateTime.may, 20).isWeekday, isTrue);
+        expect(DateTime(2026, DateTime.may, 20).isWeekend, isFalse);
+        expect(DateTime(2026, DateTime.may, 21).isWeekday, isTrue);
+        expect(DateTime(2026, DateTime.may, 21).isWeekend, isFalse);
+        expect(DateTime(2026, DateTime.may, 22).isWeekday, isTrue);
+        expect(DateTime(2026, DateTime.may, 22).isWeekend, isFalse);
+        expect(DateTime(2026, DateTime.may, 23).isWeekday, isFalse);
+        expect(DateTime(2026, DateTime.may, 23).isWeekend, isTrue);
+        expect(DateTime(2026, DateTime.may, 24).isWeekday, isFalse);
+        expect(DateTime(2026, DateTime.may, 24).isWeekend, isTrue);
+      });
       test('weekYear & weekNumber', () {
         expect(DateTime(2014, 12, 31).weekYear, 2015);
         expect(DateTime(2017, 5, 25).weekNumber, 21);


### PR DESCRIPTION
Add methods on DateTime isWeekend and isWeekday. isWeekend checks if the day is Saturday or Sunday. isWeekday checks the day falls between Monday to Friday.

Addresses issue: https://github.com/renggli/dart-more/issues/37