### PR TITLE
Feat/additional extensions iterable num

### DIFF
--- a/lib/math.dart
+++ b/lib/math.dart
@@ -2,7 +2,9 @@
 library;
 
 export 'src/math/binomial.dart'
-    show BinomialBigIntExtension, BinomialIntegerExtension;
+    show
+        BinomialBigIntExtension,
+        BinomialIntegerExtension;
 export 'src/math/bit.dart' show BitUint32Extension;
 export 'src/math/digits.dart'
     show DigitsBigIntExtension, DigitsIntegerExtension;
@@ -29,3 +31,4 @@ export 'src/math/primes/atkin.dart' show AtkinPrimeSieve;
 export 'src/math/primes/eratosthenes.dart' show EratosthenesPrimeSieve;
 export 'src/math/primes/euler.dart' show EulerPrimeSieve;
 export 'src/math/primes/sieve.dart' show PrimeSieve;
+export 'src/math/statistics.dart' show StatisticsIterableExtension;

--- a/lib/math.dart
+++ b/lib/math.dart
@@ -3,8 +3,7 @@ library;
 
 export 'src/math/binomial.dart'
     show
-        BinomialBigIntExtension,
-        BinomialIntegerExtension;
+        BinomialBigIntExtension, BinomialIntegerExtension;
 export 'src/math/bit.dart' show BitUint32Extension;
 export 'src/math/digits.dart'
     show DigitsBigIntExtension, DigitsIntegerExtension;

--- a/lib/math.dart
+++ b/lib/math.dart
@@ -2,8 +2,7 @@
 library;
 
 export 'src/math/binomial.dart'
-    show
-        BinomialBigIntExtension, BinomialIntegerExtension;
+    show BinomialBigIntExtension, BinomialIntegerExtension;
 export 'src/math/bit.dart' show BitUint32Extension;
 export 'src/math/digits.dart'
     show DigitsBigIntExtension, DigitsIntegerExtension;

--- a/lib/src/math/statistics.dart
+++ b/lib/src/math/statistics.dart
@@ -1,0 +1,75 @@
+extension StatisticsIterableExtension on Iterable<num> {
+  /// Returns the sum of the values in this [Iterable].
+  num sum() {
+    num result = 0;
+    for (final value in this) {
+      result += value;
+    }
+    return result;
+  }
+
+  /// Returns the product of the values in this [Iterable].
+  num product() {
+    num result = 1;
+    for (final value in this) {
+      result *= value;
+    }
+    return result;
+  }
+
+  /// Returns the arithmetic mean of the values in this [Iterable].
+  double mean() {
+    var count = 0;
+    num total = 0;
+    for (final value in this) {
+      count++;
+      total += value;
+    }
+    if (count == 0) {
+      throw StateError('Cannot compute the mean of an empty iterable.');
+    }
+    return total / count;
+  }
+
+  /// Returns the median of the values in this [Iterable].
+  num median() {
+    final values = toList()..sort();
+    if (values.isEmpty) {
+      throw StateError('Cannot compute the median of an empty iterable.');
+    }
+    final middle = values.length ~/ 2;
+    return values.length.isOdd
+        ? values[middle]
+        : (values[middle - 1] + values[middle]) / 2;
+  }
+
+  /// Returns the most frequent values in this [Iterable].
+  ///
+  /// If multiple values appear with the same highest frequency, all modes are
+  /// returned in the order in which they first appear.
+  ///
+  /// ```dart
+  /// [1, 4, 6, 1, 6].mode(); // [1, 6]
+  /// ```
+  List<num> mode() {
+    final counts = <num, int>{};
+    var maxCount = 0;
+    for (final value in this) {
+      final count = (counts[value] ?? 0) + 1;
+      counts[value] = count;
+      if (count > maxCount) {
+        maxCount = count;
+      }
+    }
+    if (maxCount == 0) {
+      throw StateError('Cannot compute the mode of an empty iterable.');
+    }
+    final result = <num>[];
+    for (final entry in counts.entries) {
+      if (entry.value == maxCount) {
+        result.add(entry.key);
+      }
+    }
+    return result;
+  }
+}

--- a/test/math_test.dart
+++ b/test/math_test.dart
@@ -757,6 +757,52 @@ void main() {
       expect([1, 2, 3, 4].polynomial(), 4321);
     });
   });
+  group('statistics', () {
+    test('sum', () {
+      expect(<num>[].sum(), 0);
+      expect([1, 2, 3].sum(), 6);
+      expect([1.5, 2, 3.25].sum(), 6.75);
+      expect([-1, 2, -3].sum(), -2);
+    });
+    test('product', () {
+      expect(<num>[].product(), 1);
+      expect([1, 2, 3, 4].product(), 24);
+      expect([1.5, 2, 3].product(), 9);
+      expect([-1, 2, -3].product(), 6);
+    });
+    group('mean', () {
+      test('values', () {
+        expect([1, 2, 3].mean(), 2);
+        expect([1, 2, 4].mean(), closeTo(2.3333333333333335, epsilon));
+        expect([-1, 2, -3].mean(), closeTo(-0.6666666666666666, epsilon));
+      });
+      test('empty', () {
+        expect(<num>[].mean, throwsStateError);
+      });
+    });
+    group('median', () {
+      test('values', () {
+        expect([1].median(), 1);
+        expect([3, 1, 2].median(), 2);
+        expect([4, 1, 2, 3].median(), 2.5);
+        expect([-3, 2, -1].median(), -1);
+      });
+      test('empty', () {
+        expect(<num>[].median, throwsStateError);
+      });
+    });
+    group('mode', () {
+      test('values', () {
+        expect([2, 1, 4, 3, 1].mode(), [1]);
+        expect([1, 2.7, 3.2, 4, 2.7].mode(), [2.7]);
+        expect([1, 4, 6, 1, 6].mode(), [1, 6]);
+        expect([3, 2, 1].mode(), [3, 2, 1]);
+      });
+      test('empty', () {
+        expect(<num>[].mode, throwsStateError);
+      });
+    });
+  });
   group('prime sieves', () {
     void primeSieveTests(PrimeSieve Function(int n) create) {
       test('primes', () {


### PR DESCRIPTION
Add `sum`, `product`, `mean`, `median` and `mode` on `Iterable<num>`. Tests included

Addresses issue: https://github.com/renggli/dart-more/issues/39